### PR TITLE
feat: 메인 페이지 변경

### DIFF
--- a/e2e/mock-server/lib/mock-featured-product.ts
+++ b/e2e/mock-server/lib/mock-featured-product.ts
@@ -6,6 +6,7 @@ export interface FeaturedProduct {
   productName: string; // 최대 100 자
   thumbnailUrl: string; // URL
   price: number;
+  nickname: string;
   discountRate?: number; // 0~100
   isSoldOut: boolean;
   displayOrder: number; // 1~10
@@ -22,6 +23,7 @@ export const toFeaturedProduct = (
   productName: product.productName,
   thumbnailUrl: product.imageUrl ?? "https://example.com/images/no-image.png",
   price: product.price,
+  nickname: product.nickname,
   discountRate: product.stock > 0 && product.price > 0
     ? Math.min(100, Math.floor(Math.random() * 30)) // mock: 0~30% 랜덤 할인
     : 0,
@@ -71,6 +73,7 @@ export const FeaturedProductStore = {
       productId: numericId,
       productName: data.productName,
       price: data.price,
+      nickname: data.nickname,
       stock: data.isSoldOut ? 0 : 10, // mock: 재고 단순화
       status: data.isSoldOut ? ("SOLD_OUT" as const) : ("SELLING" as const),
       imageUrl: data.thumbnailUrl !== "https://example.com/images/no-image.png"

--- a/e2e/mock-server/lib/mock-product-data.ts
+++ b/e2e/mock-server/lib/mock-product-data.ts
@@ -13,6 +13,7 @@ export interface Product {
   description?: string;
   price: number;
   stock: number;
+  nickname: string;
   type: ProductType;
   imageUrl?: string | null;
   status: ProductStatus;
@@ -46,6 +47,7 @@ let products: Product[] = [
     type: "BOOK",
     imageUrl: "https://example.com/images/spring-intro.jpg",
     status: "SELLING",
+    nickname: MOCK_USERS.SELLER.nickname,
     sellerId: MOCK_USERS.SELLER.id,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
@@ -59,6 +61,7 @@ let products: Product[] = [
     type: "EBOOK",
     imageUrl: "https://example.com/images/book1.jpg",
     status: "SELLING",
+    nickname: MOCK_USERS.SELLER.nickname,
     sellerId: MOCK_USERS.SELLER.id,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
@@ -72,6 +75,7 @@ let products: Product[] = [
     type: "EBOOK",
     imageUrl: null,
     status: "SOLD_OUT",
+    nickname: MOCK_USERS.SELLER.nickname,
     sellerId: MOCK_USERS.SELLER.id,
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
@@ -154,6 +158,7 @@ export const ProductStore = {
         type: "BOOK",
         imageUrl: "https://example.com/images/spring-intro.jpg",
         status: "SELLING",
+        nickname: MOCK_USERS.SELLER.nickname,
         sellerId: MOCK_USERS.SELLER.id,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
@@ -167,6 +172,7 @@ export const ProductStore = {
         type: "EBOOK",
         imageUrl: "https://example.com/images/book1.jpg",
         status: "SELLING",
+        nickname: MOCK_USERS.SELLER.nickname,
         sellerId: MOCK_USERS.SELLER.id,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
@@ -180,6 +186,7 @@ export const ProductStore = {
         type: "EBOOK",
         imageUrl: null,
         status: "SOLD_OUT",
+        nickname: MOCK_USERS.SELLER.nickname,
         sellerId: MOCK_USERS.SELLER.id,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),

--- a/e2e/mock-server/routes/products.routes.ts
+++ b/e2e/mock-server/routes/products.routes.ts
@@ -67,11 +67,14 @@ router.get("/", (req: Request, res: Response) => {
     const paginated = result.slice(startIndex, startIndex + pageSize);
 
     return res.status(200).json({
-      content: paginated,
-      page: pageNum,
-      size: pageSize,
-      totalElements: result.length,
-      totalPages: Math.ceil(result.length / pageSize),
+      success: true,
+      data: {
+        content: paginated,
+        page: pageNum,
+        size: pageSize,
+        totalElements: result.length,
+        totalPages: Math.ceil(result.length / pageSize),
+      }
     });
   } catch (error) {
     console.error("[GET /products] Error:", error);
@@ -120,14 +123,10 @@ router.get("/:productId", (req: Request, res: Response) => {
   }
 
   return res.status(200).json({
-    productId: product.productId,
-    productName: product.productName,
-    description: product.description,
-    price: product.price,
-    stock: product.stock,
-    imageUrl: product.imageUrl,
-    type: product.type,
-    status: product.status,
+    success:true,
+    data: {
+      ...product
+    }
   });
 });
 

--- a/e2e/mock-server/routes/store-products.routes.ts
+++ b/e2e/mock-server/routes/store-products.routes.ts
@@ -14,6 +14,7 @@ import {
   VALID_STATUSES,
   Product,
 } from "../lib/mock-product-data";
+import { MOCK_SELLER } from "../../test-case/product/fixtures/product-fixture";
 
 export const router = Router();
 
@@ -270,6 +271,7 @@ router.post("/", mockSellerMiddleware, (req: Request, res: Response) => {
     imageUrl: imageUrl || null,
     status: "SELLING",
     sellerId: user.id,
+    nickname: MOCK_SELLER.nickname, // 임시 값 !!
   });
 
   return res.status(201).json({

--- a/src/app/(public)/products/[id]/page.tsx
+++ b/src/app/(public)/products/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function ProductDetailPage({ params }: PageProps) {
 
   // ✅ 데이터 조회
   const result = await fetchProductDetail(productId);
-
+  console.log(result);
   // ❌ 에러 처리
   if (!result.success) {
     if (result.status === 404) notFound();
@@ -118,9 +118,18 @@ export default async function ProductDetailPage({ params }: PageProps) {
             </div>
 
             {/* 상품명 & 가격 */}
-            <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2 leading-tight">
-              {product.productName}
-            </h1>
+            <div className="mb-4">
+              <h1 className="text-2xl md:text-3xl font-bold text-gray-900 leading-tight">
+                {product.productName}
+              </h1>
+
+              <div className="flex items-center gap-2 mt-2 text-sm text-gray-500">
+                <span className="px-2 py-1 bg-gray-100 rounded-full text-xs text-gray-600">
+                  ✍️작가님: {product.nickname} 
+                </span>
+              </div>
+            </div>
+
             <p className="text-3xl font-bold text-blue-600 mb-6">
               {product.price.toLocaleString()}원
             </p>

--- a/src/app/(public)/products/[id]/page.tsx
+++ b/src/app/(public)/products/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function ProductDetailPage({ params }: PageProps) {
 
   // ✅ 데이터 조회
   const result = await fetchProductDetail(productId);
-  console.log(result);
+  
   // ❌ 에러 처리
   if (!result.success) {
     if (result.status === 404) notFound();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,83 +1,109 @@
 // app/page.tsx
 'use client';
 
+import { useAuthStore } from "@/stores/useAuthStore";
+import { ProductListResult, ProductSummary } from "@/types/product";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
 export default function HomePage() {
-  // 더미 데이터 (나중에 API 연동 시 사용)
-  const placeholderBooks = [1, 2, 3, 4];
+  const [products, setProducts] = useState<ProductSummary[]>([]);
+  
+  const user = useAuthStore((state) => state.user);
+  const router = useRouter();
+
+  useEffect(() => {
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/products`)
+      .then((res) => res.json())
+      .then((result: ProductListResult) => {
+        if (result.success) {
+          setProducts(result.data.content);
+        } else {
+          console.error(result.detail);
+        }
+      })
+      .catch((err) => {
+        console.error('API 에러:', err);
+      });
+  }, []);
 
   return (
     <main className="flex-grow bg-gray-50 min-h-screen pb-12">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
 
-        {/* 1. 상단 카테고리 메뉴 (상품 전체 조회) */}
-        <nav className="bg-white rounded-lg shadow-sm overflow-hidden">
-          <ul className="grid grid-cols-2 md:grid-cols-4 divide-x divide-y border border-gray-200">
-            {['상품 전체 조회', '신간 도서', '베스트셀러', '이벤트 상품'].map((item) => (
-              <li key={item}>
-                <button className="w-full py-3 text-center font-medium text-gray-700 hover:bg-blue-50 hover:text-blue-600 transition">
-                  {item}
-                </button>
-              </li>
-            ))}
-          </ul>
-        </nav>
+      {user?.role === "SELLER" && (
+        <button
+          onClick={() => router.push("/mypage")}
+          className="
+            w-full
+            h-20
+            px-6 py-3
+            bg-green-600
+            text-white
+            font-semibold
+            text-big
+            rounded-lg
+            shadow-md
+            hover:bg-blue-700
+            hover:shadow-lg
+            transition-all
+            active:scale-[0.98]
+          "
+        >
+          ⭐ 나의 판매자 공간으로 이동하기 ⭐
+        </button>
+      )}
 
-        {/* 2. 진행중인 이벤트 배너 */}
-        <section className="bg-gradient-to-r from-blue-500 to-indigo-600 rounded-xl shadow-md overflow-hidden text-white">
-          <div className="px-8 py-12 md:py-16 text-center">
-            <span className="inline-block px-3 py-1 bg-white/20 rounded-full text-xs font-semibold mb-4 backdrop-blur-sm">
-              HOT EVENT
-            </span>
-            <h2 className="text-3xl md:text-4xl font-bold mb-4">진행중인 이벤트</h2>
-            <p className="text-blue-100 max-w-2xl mx-auto">
-              신규 회원가입 시 도서 할인 쿠폰을 지급합니다. 지금 바로 확인하세요!
-            </p>
-            <button className="mt-6 px-6 py-3 bg-white text-blue-600 font-bold rounded-lg shadow hover:bg-gray-50 transition">
-              이벤트 보기
-            </button>
-          </div>
-        </section>
-
-        {/* 3. 인기 도서 / 최신 도서 (2 Column) */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          
-          {/* 인기 도서 */}
-          <section className="bg-white rounded-lg shadow-sm p-6">
+        <div className="flex gap-6">
+    
+          {/* 왼쪽: 상품 목록 */}
+          <section className="flex-1 bg-white rounded-lg shadow-sm p-6">
             <div className="flex justify-between items-center mb-6 border-b pb-4">
-              <h3 className="text-xl font-bold text-gray-800">🔥 인기 도서</h3>
-              <button className="text-sm text-blue-600 font-medium hover:underline">더보기 &gt;</button>
+              <h3 className="text-xl font-bold text-gray-800">🔥 상품 목록</h3>
+              <button 
+                onClick={() => router.push('/products')}
+                className="text-sm text-blue-600 font-medium hover:underline">더보기 &gt;</button>
             </div>
-            <div className="space-y-4">
-              {placeholderBooks.map((i) => (
-                <div key={`popular-${i}`} className="flex items-center p-3 border rounded-md hover:shadow-md transition bg-gray-50">
-                  <div className="w-12 h-16 bg-gray-300 rounded mr-4 flex-shrink-0"></div>
-                  <div>
-                    <p className="font-semibold text-gray-700">베스트셀러 도서 제목 {i}</p>
-                    <p className="text-sm text-gray-500">저자 이름 • 15,000 원</p>
-                  </div>
-                </div>
-              ))}
-            </div>
+              <div className="space-y-4">
+                {products.slice(0, 10).map((product: ProductSummary) => (
+                  <Link
+                  key={product.productId}
+                  href={`/products/${product.productId}`}
+                  className="block"
+                  >
+                    <div className="flex items-center p-3 border rounded-md hover:shadow-md transition bg-gray-50">
+                      <div className="w-12 h-16 bg-gray-300 rounded mr-4 flex-shrink-0"></div>
+                      <div>
+                      <p className="font-semibold text-gray-700">{product.productName}</p>
+                      <p className="text-sm text-gray-500">{product.nickname} • {product.price}원</p>
+                      </div>
+                    </div>
+                  </Link>
+                ))}
+              </div>
           </section>
 
-          {/* 최신 도서 */}
-          <section className="bg-white rounded-lg shadow-sm p-6">
+          {/* 오른쪽: 나중에 콘텐츠 */}
+          {/* <section className="flex-1 bg-white rounded-lg shadow-sm p-6">
             <div className="flex justify-between items-center mb-6 border-b pb-4">
-              <h3 className="text-xl font-bold text-gray-800">✨ 최신 도서</h3>
-              <button className="text-sm text-blue-600 font-medium hover:underline">더보기 &gt;</button>
-            </div>
-            <div className="space-y-4">
-              {placeholderBooks.map((i) => (
-                <div key={`new-${i}`} className="flex items-center p-3 border rounded-md hover:shadow-md transition bg-gray-50">
-                  <div className="w-12 h-16 bg-gray-300 rounded mr-4 flex-shrink-0"></div>
-                  <div>
-                    <p className="font-semibold text-gray-700">신간 도서 제목 {i}</p>
-                    <p className="text-sm text-gray-500">저자 이름 • 18,000 원</p>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </section>
+              <h3 className="text-xl font-bold text-gray-800">✨ 판매자 목록</h3> */}
+              {/* <button 
+                onClick={() => router.push('/products')}
+                className="text-sm text-blue-600 font-medium hover:underline">더보기 &gt;</button> */}
+            {/* </div>
+            <div className="space-y-4"> */}
+            {/* {placeholderBooks.map((i) => ( */}
+                  {/* <div className="flex items-center p-3 border rounded-md hover:shadow-md transition bg-gray-50">
+                    <div className="w-12 h-16 bg-gray-300 rounded mr-4 flex-shrink-0"></div>
+                    <div>
+                      <p className="font-semibold text-gray-700">신간 도서 제목</p>
+                      <p className="text-sm text-gray-500">저자 이름 • 18,000 원</p>
+                    </div>
+                  </div> */}
+                {/* ))} */}
+            {/* </div>
+          </section> */}
 
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,12 +19,9 @@ export default function HomePage() {
       .then((result: ProductListResult) => {
         if (result.success) {
           setProducts(result.data.content);
-        } else {
-          console.error(result.detail);
-        }
+        } 
       })
-      .catch((err) => {
-        console.error('API 에러:', err);
+      .catch(() => {
       });
   }, []);
 

--- a/src/components/products/ProductList.tsx
+++ b/src/components/products/ProductList.tsx
@@ -46,7 +46,7 @@ export default function ProductList({ products, pagination }: ProductListProps) 
 
   return (
     <>
-      <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
         {products.map((product) => (
           <Link
             key={product.productId}

--- a/src/lib/services/product.service.ts
+++ b/src/lib/services/product.service.ts
@@ -80,11 +80,11 @@ export async function fetchProductList(
     return {
       success: true,
       data: {
-        content: data.content,
-        page: data.page,
-        size: data.size,
-        totalElements: data.totalElements,
-        totalPages: data.totalPages,
+        content: data.data.content,
+        page: data.data.page,
+        size: data.data.size,
+        totalElements: data.data.totalElements,
+        totalPages: data.data.totalPages,
       },
     };
   } catch (error) {
@@ -135,7 +135,7 @@ export async function fetchProductDetail(
 
     return {
       success: true,
-      data: data as Product,
+      data: data.data as Product,
     };
   } catch (error) {
     console.error("[fetchProductDetail] Network Error:", error);

--- a/src/lib/services/product.service.ts
+++ b/src/lib/services/product.service.ts
@@ -17,6 +17,7 @@ import {
   ProductDeactivateResult,
   ProductActionState,
   Product,
+  ProductListResponse,
 } from "@/types/product";
 import {
   getForwardedHeaders,
@@ -75,18 +76,9 @@ export async function fetchProductList(
       return { success: false, ...parseProblemDetail(error) };
     }
 
-    const data = await response.json();
+    const data = await response.json() as ProductListResult;
 
-    return {
-      success: true,
-      data: {
-        content: data.data.content,
-        page: data.data.page,
-        size: data.data.size,
-        totalElements: data.data.totalElements,
-        totalPages: data.data.totalPages,
-      },
-    };
+    return data;
   } catch (error) {
     console.error("[fetchProductList] Network Error:", error);
     return {
@@ -131,12 +123,9 @@ export async function fetchProductDetail(
       };
     }
 
-    const data = await response.json();
+    const data = await response.json() as ProductDetailResult;
 
-    return {
-      success: true,
-      data: data.data as Product,
-    };
+    return data;
   } catch (error) {
     console.error("[fetchProductDetail] Network Error:", error);
     return {

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -10,6 +10,7 @@ export interface Product {
   description?: string;
   price: number;
   stock: number;
+  nickname: string;
   type: ProductType;
   imageUrl?: string | null;
   status: ProductStatus;
@@ -22,6 +23,7 @@ export interface ProductSummary {
   productId: number;
   productName: string;
   price: number;
+  nickname: string;
   imageUrl?: string | null;
   type: ProductType;
   status: PublicStatus;


### PR DESCRIPTION
## 📌 개요 (What)

## ✨ 작업 내용
- 메인 화면에서 상품 전체 조회 (/api/v1/products) : 최대 10개까지
- 더보기 누르면 상품 전체 조회 페이지로 이동
- 상품 클릭하면 상품 상세보기로 이동

## 🔥 변경 이유

## 🧪 테스트
- [x] 기능 정상 동작 확인
- [ ] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트

## 🔗 관련 이슈
- close #23 
