### PR TITLE
fix: 상품 등록 후 리다이렉트 오류 수정

### DIFF
--- a/src/lib/actions/product.actions.ts
+++ b/src/lib/actions/product.actions.ts
@@ -45,7 +45,7 @@ export async function handleCreateProduct(
       };
     }
 
-    productId = result.data.productId;
+    productId = (result.data as any)?.data?.productId ?? result.data?.productId;
   } catch (error) {
     return {
       success: false,


### PR DESCRIPTION
## 📌 개요 (What)
상품 등록 후 상세 페이지로 이동하는 과정에서 `productId`를 잘못 참조해 /products/undefined로 리다이렉트되던 문제를 수정했습니다.

## ✨ 작업 내용
상품 등록 액션(handleCreateProduct)에서 생성된 상품 ID 참조 수정

## 🔥 변경 이유
상품 등록 자체는 정상적으로 완료되지만, 등록 후 상세 페이지 이동 시 undefined 경로로 이동하면서 404 페이지가 표시되는 문제가 있었습니다. 실제 API 응답 구조와 프론트에서 참조하는 경로가 달라 발생한 문제라 이를 수정했습니다.

## 🧪 테스트
- [ ] 기능 정상 동작 확인
- [ ] 테스트 코드 작성

## ⚠️ 주의사항 / 리뷰 포인트
createProduct 응답 구조가 중첩된 형태라 임시로 대응한 상태입니다.

## 🔗 관련 이슈
- close #
